### PR TITLE
Fail on error cd-ing before cloning things

### DIFF
--- a/templates/jekyll_build.sh
+++ b/templates/jekyll_build.sh
@@ -10,7 +10,7 @@ if [ ! -d "$JEKYLL_SITE_PATH" ] ; then
 fi
 
 # Jump into the content path
-cd "$JEKYLL_SITE_PATH"
+cd "$JEKYLL_SITE_PATH" || { echo >&2 "Could not cd into content path: ${JEKYLL_SITE_PATH}"; exit 1; }
 
 # If we have .git update, otherwise clone
 if [ -d .git ] ; then


### PR DESCRIPTION
Seeing as we mkdir right before cd-ing, this should never fail.
However, there are cases when mkdir might fail (read-only filesystem,
permissions if we make the build non-root, other randomness).

This patch exits with an error message if the cd fails, and prevents a
git repository from being cloned into root's home directory.  It's just
[good practice](http://mywiki.wooledge.org/BashPitfalls#cd_.2Ffoo.3B_bar)
