### PR TITLE
Allow for other roles to register nginx locations

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,9 @@
   copy: src=dhparam.pem dest=/etc/nginx/dhparam.pem owner=root group=root mode=0644
   when: jekyll_use_ssl
 
+- name: Create folder for external nginx locations
+  file: path=/etc/nginx/locations.d/{{ jekyll_site_url }} state=directory owner=root group=root mode=0755
+
 - name: Install site descriptor
   template: src=jekyll.conf dest=/etc/nginx/sites-available/{{ jekyll_site_name }}.conf owner=root group=root mode=0644
   notify:

--- a/templates/jekyll.conf
+++ b/templates/jekyll.conf
@@ -10,6 +10,8 @@ server {
         location / {
                 index index.html;
         }
+
+        include /etc/nginx/locations.d/{{ jekyll_site_url }}/*.conf
         {% endif %}
 }
 
@@ -57,5 +59,7 @@ server {
         location / {
                 index index.html;
         }
+
+        include /etc/nginx/locations.d/{{ jekyll_site_url }}/*.conf
 }
 {% endif %}


### PR DESCRIPTION
Provide a folder for other jekyll roles to place nginx configuration files
that exist within a host.
